### PR TITLE
Correct the name of the field timezone

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "api",
     "searchad"
   ],
-  "version": "1.1.29",
+  "version": "1.1.30",
   "authors": [
     {
       "name": "Sergey Kubrey",

--- a/src/searchad/reports/ReportingRequest.php
+++ b/src/searchad/reports/ReportingRequest.php
@@ -25,7 +25,7 @@ use searchad\ApiRequest;
  *
  * @property string $startTime yyyy-mm-dd
  * @property string $endTime yyyy-mm-dd
- * @property string $timezone ORTZ,UTC Default ORTZ.
+ * @property string $timeZone ORTZ,UTC Default ORTZ.
  *
  * Field to group by; maximum one in the list.
  * Currently supported field options:
@@ -53,7 +53,7 @@ use searchad\ApiRequest;
 class ReportingRequest extends ApiRequest
 {
 
-    protected $granularity, $startTime, $endTime, $timezone, $groupBy, $returnRowTotals = null, $returnRecordsWithNoMetrics = false;
+    protected $granularity, $startTime, $endTime, $timeZone, $groupBy, $returnRowTotals = null, $returnRecordsWithNoMetrics = false;
     protected $selector;
 
     const GRANULARITY_DAILY = 'DAILY';
@@ -64,7 +64,7 @@ class ReportingRequest extends ApiRequest
     protected $requestBody = [];
 
     protected $requiredFields = ['startTime', 'endTime', 'selector'];
-    protected $possibleFields = ['granularity', 'timezone', 'groupBy', 'returnRowTotals', 'returnRecordsWithNoMetrics'];
+    protected $possibleFields = ['granularity', 'timeZone', 'groupBy', 'returnRowTotals', 'returnRecordsWithNoMetrics'];
 
     /**
      * POST /v1/reports/campaigns
@@ -236,9 +236,9 @@ class ReportingRequest extends ApiRequest
         return $this;
     }
 
-    public function setTimezone($tz)
+    public function setTimeZone($tz)
     {
-        $this->timezone = $tz;
+        $this->timeZone = $tz;
         return $this;
     }
 

--- a/src/searchad_v2/report/ReportingRequest.php
+++ b/src/searchad_v2/report/ReportingRequest.php
@@ -27,7 +27,7 @@ use searchad_v2\ApiRequest;
  *
  * @property string $startTime yyyy-mm-dd
  * @property string $endTime yyyy-mm-dd
- * @property string $timezone ORTZ,UTC Default ORTZ.
+ * @property string $timeZone ORTZ,UTC Default ORTZ.
  *
  * Field to group by; maximum one in the list.
  * Currently supported field options:
@@ -58,7 +58,7 @@ class ReportingRequest extends ApiRequest
     protected $granularity;
     protected $startTime;
     protected $endTime;
-    protected $timezone;
+    protected $timeZone;
     protected $groupBy;
     protected $returnRowTotals = null;
     protected $returnRecordsWithNoMetrics = false;
@@ -72,7 +72,7 @@ class ReportingRequest extends ApiRequest
     protected $requestBody = [];
 
     protected $requiredFields = ['startTime', 'endTime', 'selector'];
-    protected $possibleFields = ['granularity', 'timezone', 'groupBy', 'returnRowTotals', 'returnRecordsWithNoMetrics'];
+    protected $possibleFields = ['granularity', 'timeZone', 'groupBy', 'returnRowTotals', 'returnRecordsWithNoMetrics'];
 
     /**
      * @param $granularity
@@ -132,8 +132,8 @@ class ReportingRequest extends ApiRequest
      * @param $tz
      * @return $this
      */
-    public function setTimezone($tz) {
-        $this->timezone = $tz;
+    public function setTimeZone($tz) {
+        $this->timeZone = $tz;
 
         return $this;
     }


### PR DESCRIPTION
This PR renames the field `timezone` into `timeZone`

It has been renamed on the API side,
currently, when using `timezone` this error is raising:

```{"data":null,"pagination":null,"error":{"errors":[{"messageCode":"UNRECOGNIZED_PROPERTY","message":"This is an invalid request. The field [timezone] is not recognized by the system.","field":"timezone"}]}}```

When `timeZone` is used, no error appears and the response returns as expected.